### PR TITLE
set request method to 'PUT'

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ var postToSlack = function(input) {
     }
 
     options.body = JSON.stringify(post);
+    options.method = 'PUT';
 
     request(options, function(error, response, body) {
         if (!error && response.statusCode === 200) {


### PR DESCRIPTION
Something seems to have recently changed in the Slack Webhooks API that now requires the request method to be set explicitly to 'PUT'.
